### PR TITLE
Reinvent the logic to unmarshal attribute map to cty.Value (to support dynamic type)

### DIFF
--- a/cty.go
+++ b/cty.go
@@ -1,0 +1,349 @@
+package tfstate
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+)
+
+func UnmarshalToCty(obj map[string]interface{}, t cty.Type) (cty.Value, error) {
+	var path cty.Path
+	v, err := unmarshal(obj, t, path)
+	if err != nil {
+		switch err := err.(type) {
+		case cty.PathError:
+			return cty.NilVal, PathError{err}
+		default:
+			return cty.NilVal, err
+		}
+	}
+	return v, nil
+}
+
+func unmarshal(v interface{}, t cty.Type, path cty.Path) (cty.Value, error) {
+	if v == nil {
+		return cty.NullVal(t), nil
+	}
+
+	if t == cty.DynamicPseudoType {
+		_, v, err := unmarshalDynamic(v, path)
+		return v, err
+	}
+
+	switch {
+	case t.IsPrimitiveType():
+		val, err := unmarshalPrimitive(v, t, path)
+		if err != nil {
+			return cty.NilVal, err
+		}
+		return val, nil
+	case t.IsListType():
+		return unmarshalList(v, t.ElementType(), path)
+	case t.IsSetType():
+		return unmarshalSet(v, t.ElementType(), path)
+	case t.IsMapType():
+		return unmarshalMap(v, t.ElementType(), path)
+	case t.IsTupleType():
+		return unmarshalTuple(v, t.TupleElementTypes(), path)
+	case t.IsObjectType():
+		return unmarshalObject(v, t.AttributeTypes(), path)
+	// case t.IsCapsuleType():
+	// 	return unmarshalCapsule(v, t, path)
+	default:
+		return cty.NilVal, path.NewErrorf("unsupported type %s", t.FriendlyName())
+	}
+}
+
+func unmarshalPrimitive(v interface{}, t cty.Type, path cty.Path) (cty.Value, error) {
+	switch t {
+	case cty.Bool:
+		switch v := v.(type) {
+		case bool:
+			return cty.BoolVal(v), nil
+		case string:
+			val, err := convert.Convert(cty.StringVal(v), t)
+			if err != nil {
+				return cty.NilVal, path.NewError(err)
+			}
+			return val, nil
+		default:
+			return cty.NilVal, path.NewErrorf("bool is required")
+		}
+	case cty.Number:
+		switch v := v.(type) {
+		case string:
+			val, err := cty.ParseNumberVal(v)
+			if err != nil {
+				return cty.NilVal, path.NewError(err)
+			}
+			return val, nil
+		case float64:
+			return cty.NumberFloatVal(v), nil
+		default:
+			return cty.NilVal, path.NewErrorf("number is required")
+		}
+	case cty.String:
+		switch v := v.(type) {
+		case string:
+			return cty.StringVal(v), nil
+		case json.Number:
+			return cty.StringVal(string(v)), nil
+		case bool:
+			val, err := convert.Convert(cty.BoolVal(v), t)
+			if err != nil {
+				return cty.NilVal, path.NewError(err)
+			}
+			return val, nil
+		default:
+			return cty.NilVal, path.NewErrorf("string is required")
+		}
+	default:
+		// should never happen
+		panic("unsupported primitive type")
+	}
+}
+
+func unmarshalList(v interface{}, ety cty.Type, path cty.Path) (cty.Value, error) {
+	l, ok := v.([]interface{})
+	if !ok {
+		return cty.NilVal, path.NewErrorf("expect a slice, got %T", v)
+	}
+	var vals []cty.Value
+	{
+		path := append(path, nil)
+		for idx, elem := range l {
+			path[len(path)-1] = cty.IndexStep{
+				Key: cty.NumberIntVal(int64(idx)),
+			}
+			el, err := unmarshal(elem, ety, path)
+			if err != nil {
+				return cty.NilVal, err
+			}
+			vals = append(vals, el)
+		}
+	}
+
+	if len(vals) == 0 {
+		return cty.ListValEmpty(ety), nil
+	}
+
+	return cty.ListVal(vals), nil
+}
+
+func unmarshalSet(v interface{}, ety cty.Type, path cty.Path) (cty.Value, error) {
+	l, ok := v.([]interface{})
+	if !ok {
+		return cty.NilVal, path.NewErrorf("expect a slice, got %T", v)
+	}
+	var vals []cty.Value
+	{
+		path := append(path, nil)
+		for idx, elem := range l {
+			path[len(path)-1] = cty.IndexStep{
+				Key: cty.NumberIntVal(int64(idx)),
+			}
+			el, err := unmarshal(elem, ety, path)
+			if err != nil {
+				return cty.NilVal, err
+			}
+			vals = append(vals, el)
+		}
+	}
+
+	if len(vals) == 0 {
+		return cty.SetValEmpty(ety), nil
+	}
+
+	return cty.SetVal(vals), nil
+}
+
+func unmarshalMap(v interface{}, ety cty.Type, path cty.Path) (cty.Value, error) {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return cty.NilVal, path.NewErrorf("expect a map, got %T", v)
+	}
+	vals := make(map[string]cty.Value)
+	{
+		path := append(path, nil)
+		for k, v := range m {
+			path[len(path)-1] = cty.IndexStep{
+				Key: cty.StringVal(k),
+			}
+			el, err := unmarshal(v, ety, path)
+			if err != nil {
+				return cty.NilVal, err
+			}
+			vals[k] = el
+		}
+	}
+
+	if len(vals) == 0 {
+		return cty.MapValEmpty(ety), nil
+	}
+
+	return cty.MapVal(vals), nil
+}
+
+func unmarshalTuple(v interface{}, etys []cty.Type, path cty.Path) (cty.Value, error) {
+	l, ok := v.([]interface{})
+	if !ok {
+		return cty.NilVal, path.NewErrorf("expect a slice, got %T", v)
+	}
+	var vals []cty.Value
+	{
+		path := append(path, nil)
+		for idx, elem := range l {
+			if idx >= len(etys) {
+				return cty.NilVal, path[:len(path)-1].NewErrorf("too many tuple elements (need %d)", len(etys))
+			}
+			path[len(path)-1] = cty.IndexStep{
+				Key: cty.NumberIntVal(int64(idx)),
+			}
+			ety := etys[idx]
+			el, err := unmarshal(elem, ety, path)
+			if err != nil {
+				return cty.NilVal, err
+			}
+			vals = append(vals, el)
+		}
+	}
+
+	if len(vals) != len(etys) {
+		return cty.NilVal, path[:len(path)-1].NewErrorf("not enough tuple elements (need %d)", len(etys))
+	}
+
+	if len(vals) == 0 {
+		return cty.EmptyTupleVal, nil
+	}
+
+	return cty.TupleVal(vals), nil
+}
+
+func unmarshalObject(v interface{}, atys map[string]cty.Type, path cty.Path) (cty.Value, error) {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return cty.NilVal, path.NewErrorf("expect a map, got %T", v)
+	}
+	vals := make(map[string]cty.Value)
+
+	{
+		objPath := path           // some errors report from the object's perspective
+		path := append(path, nil) // path to a specific attribute
+
+		for k, v := range m {
+			var err error
+
+			aty, ok := atys[k]
+			if !ok {
+				return cty.NilVal, objPath.NewErrorf("unsupported attribute %q", k)
+			}
+
+			path[len(path)-1] = cty.GetAttrStep{
+				Name: k,
+			}
+
+			el, err := unmarshal(v, aty, path)
+			if err != nil {
+				return cty.NilVal, err
+			}
+
+			vals[k] = el
+		}
+	}
+
+	// Make sure we have a value for every attribute
+	for k, aty := range atys {
+		if _, exists := vals[k]; !exists {
+			vals[k] = cty.NullVal(aty)
+		}
+	}
+
+	if len(vals) == 0 {
+		return cty.EmptyObjectVal, nil
+	}
+
+	return cty.ObjectVal(vals), nil
+}
+
+func unmarshalDynamic(v interface{}, path cty.Path) (cty.Type, cty.Value, error) {
+	if v == nil {
+		return cty.DynamicPseudoType, cty.NullVal(cty.DynamicPseudoType), nil
+	}
+
+	switch v := v.(type) {
+	case bool:
+		return cty.Bool, cty.BoolVal(v), nil
+	case float64:
+		return cty.Number, cty.NumberFloatVal(v), nil
+	case string:
+		return cty.String, cty.StringVal(v), nil
+	case []interface{}:
+		eTypes := []cty.Type{}
+		eVals := []cty.Value{}
+		for idx, e := range v {
+			path := append(path, cty.IndexStep{
+				Key: cty.NumberIntVal(int64(idx)),
+			})
+			eType, eVal, err := unmarshalDynamic(e, path)
+			if err != nil {
+				return cty.NilType, cty.NilVal, err
+			}
+			eTypes = append(eTypes, eType)
+			eVals = append(eVals, eVal)
+		}
+		val := cty.TupleVal(eVals)
+		typ := cty.Tuple(eTypes)
+		return typ, val, nil
+	case map[string]interface{}:
+		attrTypes := map[string]cty.Type{}
+		attrVals := map[string]cty.Value{}
+		for k, v := range v {
+			path := append(path, cty.GetAttrStep{
+				Name: k,
+			})
+			attrType, attrVal, err := unmarshalDynamic(v, path)
+			if err != nil {
+				return cty.NilType, cty.NilVal, err
+			}
+			attrTypes[k] = attrType
+			attrVals[k] = attrVal
+		}
+		typ := cty.Object(attrTypes)
+		val := cty.ObjectVal(attrVals)
+		return typ, val, nil
+	default:
+		return cty.NilType, cty.NilVal, fmt.Errorf("Unhandled type: %T", v)
+	}
+}
+
+type PathError struct {
+	cty.PathError
+}
+
+func (e PathError) Error() string {
+	if pathStr := pathStr(e.Path); pathStr != "" {
+		return pathStr + ": " + e.PathError.Error()
+	}
+	return e.PathError.Error()
+}
+
+func pathStr(path cty.Path) string {
+	if len(path) == 0 {
+		return ""
+	}
+	var buf strings.Builder
+	for _, step := range path {
+		switch step := step.(type) {
+		case cty.GetAttrStep:
+			fmt.Fprintf(&buf, ".%s", step.Name)
+		case cty.IndexStep:
+			fmt.Fprintf(&buf, "[%#v]", step.Key)
+		default:
+			fmt.Fprintf(&buf, "<INVALID: %#v>", step)
+		}
+	}
+	return buf.String()
+}

--- a/cty_test.go
+++ b/cty_test.go
@@ -1,0 +1,142 @@
+package tfstate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestUnmarshalToCty(t *testing.T) {
+	cases := []struct {
+		name   string
+		obj    map[string]interface{}
+		typ    cty.Type
+		expect cty.Value
+	}{
+		{
+			name: "basic",
+			obj: map[string]interface{}{
+				"bool":   true,
+				"string": "abc",
+				"number": float64(123),
+				"list": []interface{}{
+					float64(1),
+					float64(2),
+					float64(3),
+				},
+				"set": []interface{}{
+					float64(1),
+					float64(2),
+					float64(3),
+				},
+				"tuple": []interface{}{true, float64(1), "a"},
+				"object": map[string]interface{}{
+					"bool": true,
+				},
+				"nested_list": []interface{}{
+					map[string]interface{}{
+						"name": "a",
+					},
+					map[string]interface{}{
+						"name": "b",
+					},
+				},
+				"nested_set": []interface{}{
+					map[string]interface{}{
+						"name": "a",
+					},
+					map[string]interface{}{
+						"name": "b",
+					},
+				},
+				"nested_tuple": []interface{}{
+					"a",
+					map[string]interface{}{
+						"name": "a",
+					},
+				},
+				"dynamic_bool":   true,
+				"dynamic_number": float64(123),
+				"dynamic_string": "abc",
+				"dynamic_tuple": []interface{}{
+					float64(1),
+					float64(2),
+					float64(3),
+				},
+				"dynamic_object": map[string]interface{}{
+					"name": "a",
+				},
+			},
+			typ: cty.Object(map[string]cty.Type{
+				"bool":           cty.Bool,
+				"string":         cty.String,
+				"number":         cty.Number,
+				"list":           cty.List(cty.Number),
+				"set":            cty.Set(cty.Number),
+				"tuple":          cty.Tuple([]cty.Type{cty.Bool, cty.Number, cty.String}),
+				"object":         cty.Object(map[string]cty.Type{"bool": cty.Bool}),
+				"nested_list":    cty.List(cty.Object(map[string]cty.Type{"name": cty.String})),
+				"nested_set":     cty.Set(cty.Object(map[string]cty.Type{"name": cty.String})),
+				"nested_tuple":   cty.Tuple([]cty.Type{cty.String, cty.Object(map[string]cty.Type{"name": cty.String})}),
+				"dynamic_bool":   cty.DynamicPseudoType,
+				"dynamic_number": cty.DynamicPseudoType,
+				"dynamic_string": cty.DynamicPseudoType,
+				"dynamic_tuple":  cty.DynamicPseudoType,
+				"dynamic_object": cty.DynamicPseudoType,
+			}),
+			expect: cty.ObjectVal(map[string]cty.Value{
+				"bool":   cty.BoolVal(true),
+				"string": cty.StringVal("abc"),
+				"number": cty.NumberFloatVal(123),
+				"list": cty.ListVal([]cty.Value{
+					cty.NumberFloatVal(1),
+					cty.NumberFloatVal(2),
+					cty.NumberFloatVal(3),
+				}),
+				"set": cty.SetVal([]cty.Value{
+					cty.NumberFloatVal(1),
+					cty.NumberFloatVal(2),
+					cty.NumberFloatVal(3),
+				}),
+				"tuple": cty.TupleVal([]cty.Value{
+					cty.BoolVal(true),
+					cty.NumberFloatVal(1),
+					cty.StringVal("a"),
+				}),
+				"object": cty.ObjectVal(map[string]cty.Value{"bool": cty.BoolVal(true)}),
+				"nested_list": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{"name": cty.StringVal("a")}),
+					cty.ObjectVal(map[string]cty.Value{"name": cty.StringVal("b")}),
+				}),
+				"nested_set": cty.SetVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{"name": cty.StringVal("a")}),
+					cty.ObjectVal(map[string]cty.Value{"name": cty.StringVal("b")}),
+				}),
+				"nested_tuple": cty.TupleVal([]cty.Value{
+					cty.StringVal("a"),
+					cty.ObjectVal(map[string]cty.Value{"name": cty.StringVal("a")}),
+				}),
+				"dynamic_bool":   cty.BoolVal(true),
+				"dynamic_number": cty.NumberFloatVal(123),
+				"dynamic_string": cty.StringVal("abc"),
+				"dynamic_tuple": cty.TupleVal([]cty.Value{
+					cty.NumberFloatVal(1),
+					cty.NumberFloatVal(2),
+					cty.NumberFloatVal(3),
+				}),
+				"dynamic_object": cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("a"),
+				}),
+			}),
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := UnmarshalToCty(tt.obj, tt.typ)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, v)
+		})
+	}
+}

--- a/state.go
+++ b/state.go
@@ -8,7 +8,6 @@ import (
 
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/zclconf/go-cty/cty"
-	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
 type State struct {
@@ -159,13 +158,9 @@ func FromJSONStateResource(resource *tfjson.StateResource, schemas *tfjson.Provi
 		Tainted:         resource.Tainted,
 		DeposedKey:      resource.DeposedKey,
 	}
-	attrsJSON, err := json.Marshal(resource.AttributeValues)
+	val, err := UnmarshalToCty(resource.AttributeValues, jsonschema.SchemaBlockImpliedType(schema.Block))
 	if err != nil {
-		return nil, fmt.Errorf("marshal %q: %v", resource.AttributeValues, err)
-	}
-	val, err := ctyjson.Unmarshal(attrsJSON, jsonschema.SchemaBlockImpliedType(schema.Block))
-	if err != nil {
-		return nil, fmt.Errorf("cty json unmarshal %q: %v", attrsJSON, err)
+		return nil, fmt.Errorf("cty json unmarshal attributes: %v", err)
 	}
 	ret.Value = val
 	return ret, nil

--- a/state_test.go
+++ b/state_test.go
@@ -22,23 +22,41 @@ func TestFromJSONStateResource(t *testing.T) {
 		ProviderName: "registry.terraform.io/magodo/demo",
 		AttributeValues: map[string]interface{}{
 			"attr_str":    "some string",
-			"attr_int":    -1,
-			"attr_uint":   1,
-			"attr_float":  0.1,
-			"attr_number": 0.5,
+			"attr_int":    float64(-1),
+			"attr_uint":   float64(1),
+			"attr_float":  float64(0.1),
+			"attr_number": float64(0.5),
 			"attr_bool":   true,
-			"attr_list":   []int{1, 2, 3},
-			"attr_set":    []int{1, 2, 3},
+			"attr_list": []interface{}{
+				float64(1),
+				float64(2),
+				float64(3),
+			},
+			"attr_set": []interface{}{
+				float64(1),
+				float64(2),
+				float64(3),
+			},
 			"attr_map": map[string]interface{}{
 				"key": "value",
 			},
 			"attr_tuple": []interface{}{
-				1,
+				float64(1),
 				map[string]interface{}{"foo": "bar"},
-				[]int{1, 2, 3},
+				[]interface{}{
+					float64(1),
+					float64(2),
+					float64(3),
+				},
 			},
 			"object": map[string]interface{}{
-				"field": 1,
+				"field": float64(1),
+				"nest": map[string]interface{}{
+					"field": "a",
+				},
+			},
+			"dynamic": map[string]interface{}{
+				"field": float64(1),
 				"nest": map[string]interface{}{
 					"field": "a",
 				},
@@ -98,6 +116,9 @@ func TestFromJSONStateResource(t *testing.T) {
 										}),
 									}),
 								},
+								"dynamic": {
+									AttributeType: cty.DynamicPseudoType,
+								},
 							},
 						},
 					},
@@ -134,17 +155,18 @@ func TestFromJSONStateResource(t *testing.T) {
 		Nest  NestObjectType `cty:"nest"`
 	}
 	type ValueGoType struct {
-		AttrStr    string            `cty:"attr_str"`
-		AttrInt    int               `cty:"attr_int"`
-		AttrUint   uint              `cty:"attr_uint"`
-		AttrFloat  float64           `cty:"attr_float"`
-		AttrNumber big.Float         `cty:"attr_number"`
-		AttrBool   bool              `cty:"attr_bool"`
-		AttrList   []int             `cty:"attr_list"`
-		AttrSet    []int             `cty:"attr_set"`
-		AttrMap    map[string]string `cty:"attr_map"`
-		AttrTuple  TupleType         `cty:"attr_tuple"`
-		AttrObject ObjectType        `cty:"object"`
+		AttrStr     string            `cty:"attr_str"`
+		AttrInt     int               `cty:"attr_int"`
+		AttrUint    uint              `cty:"attr_uint"`
+		AttrFloat   float64           `cty:"attr_float"`
+		AttrNumber  big.Float         `cty:"attr_number"`
+		AttrBool    bool              `cty:"attr_bool"`
+		AttrList    []int             `cty:"attr_list"`
+		AttrSet     []int             `cty:"attr_set"`
+		AttrMap     map[string]string `cty:"attr_map"`
+		AttrTuple   TupleType         `cty:"attr_tuple"`
+		AttrObject  ObjectType        `cty:"object"`
+		AttrDynamic ObjectType        `cty:"dynamic"`
 	}
 
 	expectResourceValue := ValueGoType{
@@ -163,6 +185,12 @@ func TestFromJSONStateResource(t *testing.T) {
 			List: []int{1, 2, 3},
 		},
 		AttrObject: ObjectType{
+			Field: 1,
+			Nest: NestObjectType{
+				Field: "a",
+			},
+		},
+		AttrDynamic: ObjectType{
 			Field: 1,
 			Nest: NestObjectType{
 				Field: "a",
@@ -198,6 +226,7 @@ func TestFromJSONStateResource(t *testing.T) {
 	require.Equal(t, ev.AttrMap, av.AttrMap)
 	require.Equal(t, ev.AttrTuple, av.AttrTuple)
 	require.Equal(t, ev.AttrObject, av.AttrObject)
+	require.Equal(t, ev.AttrDynamic, av.AttrDynamic)
 }
 
 func TestFromJSONState(t *testing.T) {


### PR DESCRIPTION
The logic is referencing the `ctyjson.Unmarshal()`, whilst add supports for the dynamic type by inferring types (as the `ctyjson.Unmarshal()` will throw error for dynamic types).